### PR TITLE
Add new error code for unreachable errors (#8312)

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -174,3 +174,22 @@ that ``Cat`` falls back to ``Any`` in a type annotation:
     # Error: Argument 1 to "feed" becomes "Any" due to an unfollowed import  [no-any-unimported]
     def feed(cat: Cat) -> None:
         ...
+
+Check that statement or expression is unreachable [unreachable]
+---------------------------------------------------------------
+
+If you use :option:`--warn-unreachable <mypy --warn-unreachable>`, mypy generates an error if it
+thinks that a statement or expression will never be executed. In most cases, this is due to
+incorrect control flow or conditional checks that are accidentally always true or false.
+
+.. code-block:: python
+
+    # mypy: warn-unreachable
+
+    def example(x: int) -> None:
+        # Error: Right operand of 'or' is never evaluated  [unreachable]
+        assert isinstance(x, int) or x == 'unused'
+
+        return
+        # Error: Statement is unreachable  [unreachable]
+        print('unreachable')

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -103,6 +103,8 @@ NO_ANY_UNIMPORTED = ErrorCode(
 NO_ANY_RETURN = ErrorCode(
     'no-any-return', 'Reject returning value with "Any" type if return type is not "Any"',
     'General')  # type: Final
+UNREACHABLE = ErrorCode(
+    'unreachable', "Warn about unreachable statements or expressions", 'General')  # type: Final
 
 # Syntax errors are often blocking.
 SYNTAX = ErrorCode(

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1235,7 +1235,7 @@ class MessageBuilder:
                   context, code=code)
 
     def unreachable_statement(self, context: Context) -> None:
-        self.fail("Statement is unreachable", context)
+        self.fail("Statement is unreachable", context, code=codes.UNREACHABLE)
 
     def redundant_left_operand(self, op_name: str, context: Context) -> None:
         """Indicates that the left operand of a boolean expression is redundant:
@@ -1249,7 +1249,8 @@ class MessageBuilder:
         it does not change the truth value of the entire condition as a whole.
         'op_name' should either be the string "and" or the string "or".
         """
-        self.fail("Right operand of '{}' is never evaluated".format(op_name), context)
+        self.fail("Right operand of '{}' is never evaluated".format(op_name),
+                  context, code=codes.UNREACHABLE)
 
     def redundant_condition_in_comprehension(self, truthiness: bool, context: Context) -> None:
         self.redundant_expr("If condition in comprehension", truthiness, context)
@@ -1261,7 +1262,8 @@ class MessageBuilder:
         self.redundant_expr("Condition in assert", truthiness, context)
 
     def redundant_expr(self, description: str, truthiness: bool, context: Context) -> None:
-        self.fail("{} is always {}".format(description, str(truthiness).lower()), context)
+        self.fail("{} is always {}".format(description, str(truthiness).lower()),
+                  context, code=codes.UNREACHABLE)
 
     def report_protocol_problems(self,
                                  subtype: Union[Instance, TupleType, TypedDictType],


### PR DESCRIPTION
Closes #8190. This introduces a new error code for errors shown when using
the `--warn-unreachable` flag, such as the "Statement is unreachable" error.